### PR TITLE
ci: Use ubuntu latest, specify rust toolchain (stable)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,18 +2,14 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
-    runs-on: ubuntu-20.04
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Run fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dino_park_gate"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Florian Merz <me@fiji-flo.de>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
These are generally from The Cargo Book section on CI:

    https://doc.rust-lang.org/cargo/guide/continuous-integration.html

Jira: [IAM-1908](https://mozilla-hub.atlassian.net/browse/IAM-1908)